### PR TITLE
fix fontification by competing compilation filter functions

### DIFF
--- a/urgrep.el
+++ b/urgrep.el
@@ -1212,7 +1212,6 @@ rerunning the search."
 (defun ugrep--finish (&rest args)
   "Called by `compilation-finish-functions' when the grep process ends."
   (ignore args)
-  (message "MODE: %S" major-mode)
   (when (and (eq 'urgrep-mode major-mode)
              (memq 'urgrep-filter compilation-filter-hook))
     (setq compilation-filter-hook


### PR DESCRIPTION
This library adds a hook to `compilation-filter-hook` to highlight the buffer as matches are found.  However, `compilation-filter-hook` is used frequently in functions that highlight the buffer with `ansi-color-apply-on-region` (for example, with the default make compilation).  Highlight functions in the compilation buffer step on each others' toes and leads to incorrect highlighting in `ugrep` buffers.

This pull request fixes this by saving `compilation-filter-hook`, then setting it with this library's highlight update function as a singleton, then reverting it to the previous value when either:

-   the process finishes
-   the `urgrep` buffer is killed in cases when the user aborts the search

Please let me know if you have any questions about the changes.